### PR TITLE
自动部署 GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: master
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup Python
+      uses: actions/setup-python@v4.2.0
+      
+    - name: Install dependencies
+      run: pip install sphinx
+      
+    - name: Build Pages
+      run: make html && cp _build/html/README.html _build/html/index.html
+      
+    - name: Upload Artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: _build/html
+        
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+    - name: Setup Pages
+      uses: actions/configure-pages@v2
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1


### PR DESCRIPTION
在每次 push 时自动编译和部署到 GitHub Pages
效果预览：https://github.com/rapiz1/MySummary https://rapiz1.github.io/MySummary/

合并后，主仓库的浏览地址为 https://Kenneth-Lee.github.io/MySummary/